### PR TITLE
try to use json to serialize arguments before using pickle

### DIFF
--- a/filecache/__init__.py
+++ b/filecache/__init__.py
@@ -117,7 +117,9 @@ def _get_cache_name(function):
     returns a name for the module's cache db.
     """
     module_name = _inspect.getfile(function)
-    cache_name = '.' + module_name
+    module_parts = module_name.rsplit('/', 1)
+    module_parts[-1] = '.' + module_parts[-1]
+    cache_name = '/'.join(module_parts)
 
     # fix for '<string>' or '<stdin>' in exec or interpreter usage.
     cache_name = cache_name.replace('<', '_lt_')

--- a/filecache/__init__.py
+++ b/filecache/__init__.py
@@ -140,7 +140,7 @@ def _log_error(error_str):
     except Exception:
         pass
 
-def _args_key(function, args, kwargs):
+def _args_key(function, args, kwargs, json_default):
     arguments = (args, kwargs)
     arguments_pickle = None
     try:
@@ -169,7 +169,7 @@ def _args_key(function, args, kwargs):
     key = function.__name__ + arguments_pickle
     return key
 
-def filecache(seconds_of_validity=None, fail_silently=False, force_sync=True):
+def filecache(seconds_of_validity=None, fail_silently=False, force_sync=True, json_default=json_default):
     '''
     filecache is called and the decorator should be returned.
     '''
@@ -177,7 +177,7 @@ def filecache(seconds_of_validity=None, fail_silently=False, force_sync=True):
         @_functools.wraps(function)
         def function_with_cache(*args, **kwargs):
             try:
-                key = _args_key(function, args, kwargs)
+                key = _args_key(function, args, kwargs, json_default)
 
                 if key in function._db:
                     rv = function._db[key]

--- a/readme.md
+++ b/readme.md
@@ -10,13 +10,13 @@ Install
 Usage
 ----
 
-    from filecache import filecache
+    from filecache import filecache, YEAR
 
     @filecache(24 * 60 * 60)
     def time_consuming_function(args):
         # etc
 
-    @filecache(filecache.YEAR)
+    @filecache(YEAR)
     def another_function(args):
         # etc
 
@@ -34,10 +34,21 @@ Usage
     makes sense because class methods are affected by changes in whatever
     is attached to self.
 
+* Note that pickling of the same arguments may result in different keys each
+    time you run interpreter so cache may be not used. You can work around this
+    problem by using json-serializable arguments. You can also defind `for_json`
+    method for any class that is used as argument.
+
+* You can install `dill` (`pip install dill`) to allow caching of functions that
+    accept lambdas, generators and some other types. But cache keys of arguments
+    may still change from run to run and so cache will miss
+
 * Tested on python 2.7 and 3.3
 
 * License: BSD, do what you wish with this. Could be awesome to hear if you found
 it useful and/or you have suggestions. ubershmekel at gmail
+
+
 
 
 Here's a trick to invalidate a single value:
@@ -48,3 +59,8 @@ Here's a trick to invalidate a single value:
 
     del somefunc._db[filecache._args_key(somefunc, (1,2,3), {})]
     # or just iterate of somefunc._db (it's a shelve, like a dict) to find the right key.
+
+By default cache is saved to file on every change. You can avoid this to save
+only on programm exit by using `@filecache.filecache(force_sync=False)`. But in
+that case cache may be lost if program extits in unclean manner (with Ctrl-Break
+or some exceptions)


### PR DESCRIPTION
`pickle.dumps` may result in different strings for "equal" objects. This can be solved by using json.dumps instead of pickle.dumps.

Example where this happens: https://bitbucket.org/imposeren/dice-calculations/src/1bc08214c9be86938fbe941bfa6436605355b121/calc_dice.py?at=master&fileviewer=file-view-default#calc_dice.py-412

And same problem on SO: http://stackoverflow.com/a/7501980/952437
