### PR TITLE
fix problem with caching parameters that contain unicode chars

### DIFF
--- a/filecache/__init__.py
+++ b/filecache/__init__.py
@@ -57,6 +57,7 @@ import functools as _functools
 import inspect as _inspect
 import os as _os
 import pickle as _pickle
+import codecs as _codecs
 import shelve as _shelve
 import sys as _sys
 import time as _time
@@ -116,7 +117,7 @@ def _args_key(function, args, kwargs):
         #       because shelve only works with proper strings.
         #       Otherwise, we'd get an exception because
         #       function.__name__ is str but dumps returns bytes.
-        arguments_pickle = _pickle.dumps(arguments, protocol=0).decode('ascii')
+        arguments_pickle = _codecs.encode(_pickle.dumps(arguments, protocol=0), "base64").decode()
         
     key = function.__name__ + arguments_pickle
     return key

--- a/filecache/test/test_filecache.py
+++ b/filecache/test/test_filecache.py
@@ -1,4 +1,4 @@
-
+# -*- coding: utf-8 -*-
 
 import unittest
 import imp
@@ -159,6 +159,20 @@ class TestFilecache(unittest.TestCase):
         
         second = instance.donothing(1)
         self.assertEqual(first, second)
+
+    def test_utf_8_string(self):
+        ran_once = {}
+
+        @filecache.filecache
+        def parse_pounds(x):
+            if 'yes' in ran_once:
+                return 12345
+            else:
+                ran_once['yes'] = 1
+                return x
+
+        self.assertEqual(parse_pounds("¼ pounds"), "¼ pounds")
+        self.assertEqual(parse_pounds("¼ pounds"), "¼ pounds")
 
 class NotInnerClass:
     def __init__(self):


### PR DESCRIPTION
Steps to reproduce the problem fixed:
```
Python 3.6.4 (default, Jan  6 2018, 11:49:38) 
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import filecache
>>> @filecache.filecache(filecache.YEAR)
... def print_bla(string_dubious_source):
...     print(string_dubious_source)
... 
>>> print_bla("hello")
hello
>>> print_bla("hello")
>>> print_bla("¼ pounds")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/richardspindler/projects/filecache/filecache/__init__.py", line 132, in function_with_cache
    key = _args_key(function, args, kwargs)
  File "/Users/richardspindler/projects/filecache/filecache/__init__.py", line 119, in _args_key
    arguments_pickle = _pickle.dumps(arguments, protocol=0).decode('ascii')
UnicodeDecodeError: 'ascii' codec can't decode byte 0xbc in position 3: ordinal not in range(128)
>>> 

```