### PR TITLE
Add typing support

### DIFF
--- a/filecache/__init__.py
+++ b/filecache/__init__.py
@@ -210,10 +210,10 @@ def filecache(
                 fail_silently=fail_silently,
             )
 
-        # support for when people use '@filecache.filecache' instead of '@filecache.filecache()'
         return filecache_decorator
 
     else:
+        # support for when people use '@filecache.filecache' instead of '@filecache.filecache()'
         fast_wrapper = CachedFileCacheCallable(
             arg0,
             seconds_of_validity=None,

--- a/filecache/__init__.py
+++ b/filecache/__init__.py
@@ -62,30 +62,38 @@ import shelve as _shelve
 import sys as _sys
 import time as _time
 import traceback as _traceback
-import types
+import typing
 import atexit
 
-_retval = _collections.namedtuple('_retval', 'timesig data')
-_SRC_DIR = _os.path.dirname(_os.path.abspath(__file__))
+P = typing.ParamSpec('P')
+T = typing.TypeVar('T')
+R = typing.TypeVar('R')
+C = typing.TypeVar('C', bound=typing.Callable[..., typing.Any])
 
-SECOND = 1
-MINUTE = 60 * SECOND
-HOUR = 60 * MINUTE
-DAY = 24 * HOUR
-WEEK = 7 * DAY
-MONTH = 30 * DAY
-YEAR = 365 * DAY
-FOREVER = None
+class _retval(typing.NamedTuple, typing.Generic[T]):
+    timesig: float
+    data: T
 
-OPEN_DBS = dict()
+_SRC_DIR: typing.Final[str] = _os.path.dirname(_os.path.abspath(__file__))
 
-def _get_cache_name(function):
+SECOND: typing.Final[int] = 1
+MINUTE: typing.Final[int] = 60 * SECOND
+HOUR: typing.Final[int] = 60 * MINUTE
+DAY: typing.Final[int] = 24 * HOUR
+WEEK: typing.Final[int] = 7 * DAY
+MONTH: typing.Final[int] = 30 * DAY
+YEAR: typing.Final[int] = 365 * DAY
+FOREVER: typing.Final[typing.Literal[None]] = None
+
+OPEN_DBS: typing.Final[dict[str, _shelve.Shelf]] = dict()
+
+def _get_cache_name(function: typing.Callable[..., typing.Any]) -> str:
     """
     returns a name for the module's cache db.
     """
     module_name = _inspect.getfile(function)
     cache_name = module_name
-    
+
     # fix for '<string>' or '<stdin>' in exec or interpreter usage.
     cache_name = cache_name.replace('<', '_lt_')
     cache_name = cache_name.replace('>', '_gt_')
@@ -94,7 +102,7 @@ def _get_cache_name(function):
     return cache_name
 
 
-def _log_error(error_str):
+def _log_error(error_str: str) -> None:
     try:
         error_log_fname = _os.path.join(_SRC_DIR, 'filecache.err.log')
         if _os.path.isfile(error_log_fname):
@@ -106,81 +114,173 @@ def _log_error(error_str):
     except Exception:
         pass
 
-def _args_key(function, args, kwargs):
+def _args_key(function: typing.Callable[P, typing.Any], args: P.args, kwargs: P.kwargs) -> str:
     arguments = (args, kwargs)
     # Check if you have a valid, cached answer, and return it.
     # Sadly this is python version dependant
+    arguments_pickle: str
     if _sys.version_info[0] == 2:
-        arguments_pickle = _pickle.dumps(arguments)
+        arguments_pickle = typing.cast(str, _pickle.dumps(arguments))
     else:
         # NOTE: protocol=0 so it's ascii, this is crucial for py3k
         #       because shelve only works with proper strings.
         #       Otherwise, we'd get an exception because
         #       function.__name__ is str but dumps returns bytes.
         arguments_pickle = _codecs.encode(_pickle.dumps(arguments, protocol=0), "base64").decode()
-        
+
     key = function.__name__ + arguments_pickle
     return key
 
-def filecache(seconds_of_validity=None, fail_silently=False):
+
+class FileCacheCallable(typing.Protocol[C]):
+    """
+    `Protocol` of a file cache wrapping a callable.
+    """
+    _db: _shelve.Shelf
+    __wrapped__: C
+    __call__: C
+    __name__: str
+
+    @typing.overload
+    def __get__(
+        self: 'FileCacheCallable[C]',
+        instance: None,
+        owner: type | None = ...,
+    ) -> 'FileCacheCallable[C]': ...
+
+    @typing.overload
+    def __get__(
+        self: 'FileCacheCallable[typing.Callable[..., R]]',
+        instance: object,
+        owner: type | None = ...,
+    ) -> 'FileCacheBoundCallable[typing.Callable[..., R]]': ...
+
+
+class FileCacheBoundCallable(FileCacheCallable[C]):
+    """
+    A `FileCacheCallable` that is bound like a method.
+    """
+    __self__: object
+    __call__: C
+
+    def __init__(self, call: FileCacheCallable[C], __self__: object):
+        self._call = call
+        self.__self__ = __self__
+        self.__wrapped__ = call.__wrapped__
+        self._db = call._db
+        self.__name__ = call.__name__
+
+    def __get__(
+        self: 'FileCacheBoundCallable[C]',
+        instance: typing.Any,
+        owner: type | None = None,
+    ) -> 'FileCacheBoundCallable[C]':
+        result = self._call.__get__(instance, owner)
+        return typing.cast(FileCacheBoundCallable[C], result)
+
+    def __call__(self, *args, **kwargs): # type: ignore
+        return self._call(self.__self__, *args, **kwargs)
+
+    def __func__(self) -> FileCacheCallable[C]:
+        return self._call
+
+
+@typing.overload
+def filecache(arg0: C) -> FileCacheCallable[C]: ...
+
+@typing.overload
+def filecache(
+    arg0: int | float | None = None,
+    fail_silently: bool = False,
+) -> typing.Callable[[C], FileCacheCallable[C]]: ...
+
+
+def filecache(
+    arg0: C | int | float | None = None,
+    fail_silently: bool = False,
+) -> FileCacheCallable[C] | typing.Callable[[C], FileCacheCallable[C]]:
     '''
     filecache is called and the decorator should be returned.
     '''
-    def filecache_decorator(function):
-        @_functools.wraps(function)
-        def function_with_cache(*args, **kwargs):
-            try:
-                key = _args_key(function, args, kwargs)
-                
-                if key in function._db:
-                    rv = function._db[key]
-                    if seconds_of_validity is None or _time.time() - rv.timesig < seconds_of_validity:
-                        return rv.data
-            except Exception:
-                # in any case of failure, don't let filecache break the program
-                error_str = _traceback.format_exc()
-                _log_error(error_str)
-                if not fail_silently:
-                    raise
-            
-            retval = function(*args, **kwargs)
+    if arg0 is None or isinstance(arg0, (int, float)):
+        def filecache_decorator(call: C) -> FileCacheCallable[C]:
+            return CachedFileCacheCallable(
+                call,
+                seconds_of_validity=arg0,
+                fail_silently=fail_silently,
+            )
 
-            # store in cache
-            # NOTE: no need to _db.sync() because there was no mutation
-            # NOTE: it's importatnt to do _db.sync() because otherwise the cache doesn't survive Ctrl-Break!
-            try:
-                function._db[key] = _retval(_time.time(), retval)
-                function._db.sync()
-            except Exception:
-                # in any case of failure, don't let filecache break the program
-                error_str = _traceback.format_exc()
-                _log_error(error_str)
-                if not fail_silently:
-                    raise
-            
-            return retval
-
-        # make sure cache is loaded
-        if not hasattr(function, '_db'):
-            cache_name = _get_cache_name(function)
-            if cache_name in OPEN_DBS:
-                function._db = OPEN_DBS[cache_name]
-            else:
-                function._db = _shelve.open(cache_name)
-                OPEN_DBS[cache_name] = function._db
-                atexit.register(function._db.close)
-            
-            function_with_cache._db = function._db
-        
-        return function_with_cache
-
-    if type(seconds_of_validity) == types.FunctionType:
         # support for when people use '@filecache.filecache' instead of '@filecache.filecache()'
-        func = seconds_of_validity
-        seconds_of_validity = None
-        return filecache_decorator(func)
-    
-    return filecache_decorator
+        return filecache_decorator
+
+    else:
+        fast_wrapper = CachedFileCacheCallable(
+            arg0,
+            seconds_of_validity=None,
+            fail_silently=fail_silently,
+        )
+        return _functools.update_wrapper(fast_wrapper, arg0)
 
 
+class CachedFileCacheCallable(FileCacheCallable[C]):
+    __wrapped__: C
+    _db: _shelve.Shelf
+    _seconds_of_validity: int | float | None
+    _fail_silently: bool
 
+    def __init__(self, call: C, seconds_of_validity: int | float | None = None, fail_silently: bool = False):
+        self.__wrapped__ = call
+        self.__name__ = call.__name__
+
+        cache_name: str = _get_cache_name(call)
+        db: _shelve.Shelf
+        if cache_name in OPEN_DBS:
+            db = OPEN_DBS[cache_name]
+        else:
+            db = _shelve.open(cache_name)
+            OPEN_DBS[cache_name] = db
+            atexit.register(db.close)
+
+        self._db = db
+        self._seconds_of_validity = seconds_of_validity
+        self._fail_silently = fail_silently
+
+    def __get__(self, instance: object, owner: type | None = None) -> FileCacheCallable[C]:
+        if instance is None:
+            return self
+        return FileCacheBoundCallable(self, instance)
+
+    def __call__(self, *args, **kwargs) -> None: # type: ignore
+        try:
+            key: str = _args_key(self.__wrapped__, args, kwargs)
+
+            if key in self._db:
+                rv = self._db[key]
+                seconds_of_validity = self._seconds_of_validity
+                if seconds_of_validity is None or _time.time() - rv.timesig < seconds_of_validity:
+                    return rv.data
+
+        except Exception:
+            # in any case of failure, don't let filecache break the program
+            error_str = _traceback.format_exc()
+            _log_error(error_str)
+            fail_silently = self._fail_silently
+            if not fail_silently:
+                raise
+        
+        retval = self.__wrapped__(*args, **kwargs)
+
+        # store in cache
+        # NOTE: no need to _db.sync() because there was no mutation
+        # NOTE: it's importatnt to do _db.sync() because otherwise the cache doesn't survive Ctrl-Break!
+        try:
+            self._db[key] = _retval(_time.time(), retval)
+            self._db.sync()
+        except Exception:
+            # in any case of failure, don't let filecache break the program
+            error_str = _traceback.format_exc()
+            _log_error(error_str)
+            if not fail_silently:
+                raise
+
+        return retval

--- a/filecache/__init__.py
+++ b/filecache/__init__.py
@@ -65,11 +65,6 @@ import traceback as _traceback
 import typing
 import atexit
 
-P = typing.ParamSpec('P')
-T = typing.TypeVar('T')
-R = typing.TypeVar('R')
-C = typing.TypeVar('C', bound=typing.Callable[..., typing.Any])
-
 class _retval(typing.NamedTuple, typing.Generic[T]):
     timesig: float
     data: T
@@ -86,6 +81,11 @@ YEAR: typing.Final[int] = 365 * DAY
 FOREVER: typing.Final[typing.Literal[None]] = None
 
 OPEN_DBS: typing.Final[dict[str, _shelve.Shelf]] = dict()
+
+P = typing.ParamSpec('P')
+T = typing.TypeVar('T')
+R = typing.TypeVar('R')
+C = typing.TypeVar('C', bound=typing.Callable[..., typing.Any])
 
 def _get_cache_name(function: typing.Callable[..., typing.Any]) -> str:
     """

--- a/filecache/test/stub_for_test.py
+++ b/filecache/test/stub_for_test.py
@@ -3,5 +3,5 @@ import time
 from filecache import filecache
 
 @filecache(30)
-def the_time():
+def the_time() -> float:
     return time.time()

--- a/filecache/test/test_filecache.py
+++ b/filecache/test/test_filecache.py
@@ -6,11 +6,12 @@ import imp
 import time
 import random
 import os
+import typing
 
 import filecache
 
 
-def erase_all_cache_files():
+def erase_all_cache_files() -> None:
     # Cache files are usually next to the code (__file__) except
     # for when it's an interpreter which just goes to wherever the
     # current process directory is.
@@ -22,7 +23,7 @@ def erase_all_cache_files():
         erase_dir_cache_files(process_dir)
 
 
-def erase_dir_cache_files(dir_path):
+def erase_dir_cache_files(dir_path: str) -> None:
     shelve_suffixes = ('.cache', '.cache.bak', '.cache.dir', '.cache.dat')
     # os.listdir doesn't accept an empty string but dirname returns ''
     fname_list = os.listdir(dir_path)
@@ -39,6 +40,8 @@ def erase_dir_cache_files(dir_path):
 # NOTE: this comes so early so that the NotInnerClass's @filecache isn't erased from the disk
 erase_all_cache_files()
 
+T = typing.TypeVar('T')
+
 class TestFilecache(unittest.TestCase):
 
     #@classmethod               
@@ -49,21 +52,21 @@ class TestFilecache(unittest.TestCase):
     #def tearDownClass(self):
     #    self.erase_all_cache_files()
     
-    def test_returns(self):
+    def test_returns(self) -> None:
         # make sure the thing works
         @filecache.filecache(30)
-        def donothing(x):
+        def donothing(x: T) -> T:
             return x
 
-        params = [1, 'a', 'asdfa', set([1,2,3])]
+        params: list[object] = [1, 'a', 'asdfa', set([1,2,3])]
         for item in params:
             self.assertEqual(donothing(item), item)
         
-    def test_speeds(self):
-        DELAY = 0.5
+    def test_speeds(self) -> None:
+        DELAY: typing.Final[float] = 0.5
 
         @filecache.filecache(60)
-        def waiter(x):
+        def waiter(x: int) -> int:
             time.sleep(DELAY)
             return x
 
@@ -77,11 +80,11 @@ class TestFilecache(unittest.TestCase):
         # ran it 4 times but it should run faster than DELAY * 4
         self.assertLess(finish - start, (DELAY * 2))
 
-    def test_simple_decorate(self):
-        ran_once = {}
+    def test_simple_decorate(self) -> None:
+        ran_once: dict[str, int] = {}
 
         @filecache.filecache
-        def whatever(x):
+        def whatever(x: int) -> int:
             if 'yes' in ran_once:
                 return 12345
             else:
@@ -91,23 +94,23 @@ class TestFilecache(unittest.TestCase):
         self.assertEqual(whatever(2), 2)
         self.assertEqual(whatever(2), 2)
 
-    def test_invalidates(self):
-        wait = 0.1
-        items = [1337, 69]
-        
+    def test_invalidates(self) -> None:
+        wait: float = 0.1
+        items: list[int] = [1337, 69]
+
         @filecache.filecache(wait)
-        def popper():
+        def popper() -> int:
             return items.pop()
 
-        first = popper()
+        first: int = popper()
         # I would wait just for 'wait' exactly but time.time() isn't accurate enough.
         time.sleep(wait * 1.1)
-        second = popper()
+        second: int = popper()
         
         self.assertNotEqual(first, second)
 
-    def test_works_after_reload(self):
-        import stub_for_test
+    def test_works_after_reload(self) -> None:
+        from . import stub_for_test
         first = stub_for_test.the_time()
         # sleep a bit because time.time() == time.time()
         time.sleep(0.1)
@@ -115,7 +118,7 @@ class TestFilecache(unittest.TestCase):
         second = stub_for_test.the_time()
         self.assertEqual(first, second)
     
-    def test_interpreter_usage(self):
+    def test_interpreter_usage(self) -> None:
         '''
         This test is good for exec or interpreter usage of filecache.
         
@@ -124,30 +127,30 @@ class TestFilecache(unittest.TestCase):
         e.g. old exception:
         IOError: [Errno 22] Invalid argument: '<string>.cache.dat'
         '''
-        d = {}
+        d: dict[str, typing.Callable[[int], int]] = {}
         exec('''from filecache import filecache\n@filecache(60)\ndef function(x): return x''',d ,d)
         first = d['function'](13)
         second = d['function'](13)
         self.assertEqual(first, second)
     
-    def test_error_handling(self):
+    def test_error_handling(self) -> None:
         
         temp = filecache._log_error
         try:
-            passed_test = [False]
+            passed_test: list[bool] = [False]
             def mock_logger(*args, **kwargs):
                 passed_test[0] = True
             
             filecache._log_error = mock_logger
             
-            def popper():
+            def popper() -> str:
                 return 'arbitrary obj here'
             
-            # put anything in _db that you know will break filecache
-            popper._db = 123
-            
             popper = filecache.filecache(0.1, fail_silently=True)(popper)
-            
+
+            # put anything in _db that you know will break filecache
+            popper._db = 123  # type: ignore[assignment]
+             
             first = popper()
             
             self.assertTrue(passed_test[0])
@@ -156,14 +159,15 @@ class TestFilecache(unittest.TestCase):
 
     # TODO: maybe make class methods work somehow, problem is methods rely on instance
     #       members so I'd have to serialize the class maybe. A bit complex.
-    def AAA_test_class_methods(self):
+    def AAA_test_class_methods(self) -> None:
         # won't work because class A isn't picklable
         class A:
+            number: int
             def __init__(self):
                 self.number = 1
             
-            @filecache.filecache(5.0)
-            def donothing(self, x):
+            @filecache.filecache
+            def donothing(self, x: int) -> int:
                 self.number += x
                 return self.number
         
@@ -173,11 +177,11 @@ class TestFilecache(unittest.TestCase):
         second = instance.donothing(1)
         self.assertEqual(first, second)
 
-    def test_utf_8_string(self):
-        ran_once = {}
+    def test_utf_8_string(self) -> None:
+        ran_once: dict[str, int] = {}
 
         @filecache.filecache
-        def parse_pounds(x):
+        def parse_pounds(x: str) -> str | int:
             if 'yes' in ran_once:
                 return 12345
             else:
@@ -188,11 +192,11 @@ class TestFilecache(unittest.TestCase):
         self.assertEqual(parse_pounds("¼ pounds"), "¼ pounds")
     
     
-    def test_datetime_args(self):
+    def test_datetime_args(self) -> None:
         start = datetime.datetime.utcnow()
 
         @filecache.filecache(100)
-        def go_back_an_hour(dt):
+        def go_back_an_hour(dt: datetime.datetime) -> datetime.datetime:
             return dt - datetime.timedelta(hours=1)
 
         new_time = go_back_an_hour(start)
@@ -201,11 +205,12 @@ class TestFilecache(unittest.TestCase):
         self.assertTrue(new_time < start, "Somehow datetime subtraction did not work")
 
 class NotInnerClass:
-    def __init__(self):
+    number: int
+    def __init__(self) -> None:
         self.number = 1
     
     @filecache.filecache(5.0)
-    def donothing(self, x):
+    def donothing(self, x: int) -> int:
         self.number += x
         return self.number
 


### PR DESCRIPTION
This PR adds typing support to `filecache`, turning it into a type-safe library.

It is type-checked using [mypy](https://mypy.readthedocs.io/en/stable/):

```shell
$ python -m mypy --version
mypy 1.6.0 (compiled: yes)
$ python -m mypy filecache
Success: no issues found in 3 source files
```

It also passes all tests:

```shell
$ python -m filecache.test.test_filecache
\filecache\filecache\test\test_filecache.py:5: DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses
  import imp
erasing \filecache\filecache\test\stub_for_test.py.cache.bak
erasing \filecache\filecache\test\stub_for_test.py.cache.dat
erasing \filecache\filecache\test\stub_for_test.py.cache.dir
erasing \filecache\filecache\test\test_filecache.py.cache.bak
erasing \filecache\filecache\test\test_filecache.py.cache.dat
erasing \filecache\filecache\test\test_filecache.py.cache.dir
erasing \filecache\_lt_string_gt_.cache.bak
erasing \filecache\_lt_string_gt_.cache.dat
erasing \filecache\_lt_string_gt_.cache.dir
.........
----------------------------------------------------------------------
Ran 9 tests in 0.807s

OK
```

This implementation transfers all the caching logic into the `CachedFileCacheCallable` class, which is callable and acts like a function. This makes the `filecache` decorator a lot more clean.

The typing implementation is based on https://github.com/maxfischer2781/asyncstdlib/blob/master/asyncstdlib/_lrucache.pyi. It makes the `filecache` decorator type-check on both plain functions and methods.

Feel free to change as desired, specially variable naming. 